### PR TITLE
[TS-184] updated heroku_app_name for test back-end [HOT-FIX]

### DIFF
--- a/.github/workflows/deploy_testing.yml
+++ b/.github/workflows/deploy_testing.yml
@@ -13,5 +13,5 @@ jobs:
       - uses: akhileshns/heroku-deploy@v3.12.12 # This is the action
         with:
           heroku_api_key: "2b6f91d1-f9b7-4201-94be-3ea636871827"
-          heroku_app_name: "ancient-waters-32375" #Must be unique in Heroku
+          heroku_app_name: "tradeshare-backend-for-test" #Must be unique in Heroku
           heroku_email: "kenn.tnguyen@gmail.com"


### PR DESCRIPTION
1. Updated `heroku_app_name` for test back-end. This hosted back-end will connect to the test database and handle CI test. Hence, our tests on CI won't pollute the development database.