### PR TITLE
[TS-317] APIs for follow/unfollow a public account

### DIFF
--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -40,8 +40,8 @@ class UserController {
 	 * @param id User id to be deleted
 	 * @returns
 	 */
-	async deleteUser(id: UserFindParameters["id"]): Promise<MessageResponse> {
-		return await this.userService.deleteUser(id);
+	deleteUser(id: UserFindParameters["id"]): Promise<MessageResponse> {
+		return this.userService.deleteUser(id);
 	}
 
 	/**
@@ -49,8 +49,8 @@ class UserController {
 	 * @param originalParam User id or username
 	 * @returns response with the user found
 	 */
-	async getUser(originalParam: UserFindParameters): Promise<MessageResponse> {
-		return await this.userService.getUser(originalParam);
+	getUser(originalParam: UserFindParameters): Promise<MessageResponse> {
+		return this.userService.getUser(originalParam);
 	}
 
 	/**
@@ -59,8 +59,8 @@ class UserController {
 	 * @param input content for update
 	 * @returns response with new User object
 	 */
-	async updateUser(id: UserFindParameters["id"], input: any): Promise<MessageResponse> {
-		return await this.userService.updateUser(id, input);
+	updateUser(id: UserFindParameters["id"], input: any): Promise<MessageResponse> {
+		return this.userService.updateUser(id, input);
 	}
 }
 

--- a/src/controllers/userInfo.controller.ts
+++ b/src/controllers/userInfo.controller.ts
@@ -17,6 +17,11 @@ class UserInfoController {
 		return res.send(await this.userInfoService.findUserInfo({ userId: userId }));
 	}
 
+	async getUserInfos(req: Request, res: Response) {
+		const result = await this.userInfoService.getUserInfos(req.query);
+		return result.success ? res.send(result) : res.status(400).send(result);
+	}
+
 	async updateUserInfo(req: Request, res: Response) {
 		const userId = new mongoose.Types.ObjectId(req.params.userId);
 		const updatedInfo = await this.userInfoService.updateUserInfo({ userId: userId }, req.body, {
@@ -26,9 +31,9 @@ class UserInfoController {
 	}
 
 	async updateAlpacaToken(req: Request, res: Response) {
-		const clientId = process.env.CLIENT_ID as string
-		const clientSecret = process.env.CLIENT_SECRET as string
-		const redirectURI = process.env.REDIRECT_URI as string
+		const clientId = process.env.CLIENT_ID as string;
+		const clientSecret = process.env.CLIENT_SECRET as string;
+		const redirectURI = process.env.REDIRECT_URI as string;
 		let code = req.body.code;
 		const userId = new mongoose.Types.ObjectId(req.params.userId);
 		const params = new URLSearchParams();
@@ -39,14 +44,14 @@ class UserInfoController {
 		params.append("redirect_uri", redirectURI);
 
 		try {
-			const {data} = await axios.post("https://api.alpaca.markets/oauth/token", params, {
+			const { data } = await axios.post("https://api.alpaca.markets/oauth/token", params, {
 				headers: {
 					"Content-Type": "application/x-www-form-urlencoded",
 				},
 			});
-			if(!data.access_token){
+			if (!data.access_token) {
 				return res.status(500).send("No token");
-			 }
+			}
 			const alpacaToken = data.access_token;
 			const updatedInfo = await this.userInfoService.updateUserInfo(
 				{ userId: userId },

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,6 @@ const cleanUpServer = async () => {
 		else {
 			await neo4j.disconnect();
 			await mongoInstance.disconnect();
-			console.log("exit ?");
 			process.exit();
 		}
 	});

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,20 +25,20 @@ const server = app.listen(PORT, async () => {
 });
 
 // Called when the server is either crashed or termininated
-// const cleanUpServer = async () => {
-// 	server.close(async (err) => {
-// 		if (err) console.log(err.message);
-// 		else {
-// 			await neo4j.disconnect();
-// 			await mongoInstance.disconnect();
-// 			console.log("exit ?");
-// 			process.exit();
-// 		}
-// 	});
-// };
+const cleanUpServer = async () => {
+	server.close(async (err) => {
+		if (err) console.log(err.message);
+		else {
+			await neo4j.disconnect();
+			await mongoInstance.disconnect();
+			console.log("exit ?");
+			process.exit();
+		}
+	});
+};
 
-// const errorCodeArr = [`exit`, `SIGINT`];
+const errorCodeArr = [`exit`, `SIGINT`];
 
-// errorCodeArr.forEach((eventType) => {
-// 	process.on(eventType, cleanUpServer.bind(null, eventType));
-// });
+errorCodeArr.forEach((eventType) => {
+	process.on(eventType, cleanUpServer.bind(null, eventType));
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,19 +25,20 @@ const server = app.listen(PORT, async () => {
 });
 
 // Called when the server is either crashed or termininated
-const cleanUpServer = async () => {
-	server.close(async (err) => {
-		if (err) console.log(err.message);
-		else {
-			await neo4j.disconnect();
-			await mongoInstance.disconnect();
-			process.exit();
-		}
-	});
-};
+// const cleanUpServer = async () => {
+// 	server.close(async (err) => {
+// 		if (err) console.log(err.message);
+// 		else {
+// 			await neo4j.disconnect();
+// 			await mongoInstance.disconnect();
+// 			console.log("exit ?");
+// 			process.exit();
+// 		}
+// 	});
+// };
 
-const errorCodeArr = [`exit`, `SIGINT`, `SIGUSR1`, `SIGUSR2`, `uncaughtException`, `SIGTERM`];
+// const errorCodeArr = [`exit`, `SIGINT`];
 
-errorCodeArr.forEach((eventType) => {
-	process.on(eventType, cleanUpServer.bind(null, eventType));
-});
+// errorCodeArr.forEach((eventType) => {
+// 	process.on(eventType, cleanUpServer.bind(null, eventType));
+// });

--- a/src/modules/follows/FollowController.ts
+++ b/src/modules/follows/FollowController.ts
@@ -1,0 +1,37 @@
+import { Request, Response } from "express";
+import FollowService from "./FollowService";
+
+class FollowController {
+	private followService: FollowService;
+	constructor() {
+		this.followService = new FollowService();
+	}
+
+	async getFollows(req: Request, res: Response) {
+		const userId = req.params.userId || "-1";
+		const response = await this.followService.getFollows(userId);
+		return response.success ? res.send(response.data) : res.status(400).send(response);
+	}
+
+	async getFollowers(req: Request, res: Response) {
+		const userId = req.params.userId || "-1";
+		const response = await this.followService.getFollowers(userId);
+		return response.success ? res.send(response.data) : res.status(400).send(response);
+	}
+
+	async follows(req: Request, res: Response) {
+		const actorId = req.body.actorId || "-1";
+		const targetId = req.body.targetId || "-1";
+		const response = await this.followService.follow(actorId, targetId);
+		return response.success ? res.send(response.data) : res.status(400).send(response);
+	}
+
+	async unfollows(req: Request, res: Response) {
+		const actorId = req.body.actorId || "-1";
+		const targetId = req.body.targetId || "-1";
+		const response = await this.followService.unFollow(actorId, targetId);
+		return response.success ? res.send(response.data) : res.status(400).send(response);
+	}
+}
+
+export default FollowController;

--- a/src/modules/follows/FollowRoute.ts
+++ b/src/modules/follows/FollowRoute.ts
@@ -1,0 +1,32 @@
+import { Express, Router } from "express";
+import requireUser from "../../middleware/requireUser";
+import FollowController from "./FollowController";
+
+const followRoute = (app: Express) => {
+	const controller = new FollowController();
+	const router = Router();
+
+	// get followings
+	router.get("/follows/:userId", requireUser, (req, res) => {
+		controller.getFollows(req, res);
+	});
+
+	// get followers
+	router.get("/followers/:userId", requireUser, (req, res) => {
+		controller.getFollowers(req, res);
+	});
+
+	// follow another
+	router.post("/follow", requireUser, (req, res) => {
+		controller.follows(req, res);
+	});
+
+	// unfollow another
+	router.post("/unfollow", requireUser, (req, res) => {
+		controller.unfollows(req, res);
+	});
+
+	app.use("/api/v1/following/", router);
+};
+
+export default followRoute;

--- a/src/routes/v1/index.ts
+++ b/src/routes/v1/index.ts
@@ -1,22 +1,24 @@
-import { Express } from 'express';
-import defaultRoute from './default.route';
-import sessionRoute from './session.route';
-import userRoute from './user.route'
-import userInfoRoute from './userInfo.route'
-import accountRoute from './account.route'
-import positionsRoute from './positions.route'
-import activitiesRoute from './activities.route'
-import searchRoute from './search.route';
+import { Express } from "express";
+import defaultRoute from "./default.route";
+import sessionRoute from "./session.route";
+import userRoute from "./user.route";
+import userInfoRoute from "./userInfo.route";
+import accountRoute from "./account.route";
+import positionsRoute from "./positions.route";
+import activitiesRoute from "./activities.route";
+import searchRoute from "./search.route";
+import followRoute from "../../modules/follows/FollowRoute";
 
 module.exports = function (app: Express) {
-  // Register the routes
-  defaultRoute(app)
-  userRoute(app)
-  sessionRoute(app)
-  userInfoRoute(app)
-  accountRoute(app)
-  positionsRoute(app)
-  activitiesRoute(app)
-  searchRoute(app)
-  //other routes..
+	// Register the routes
+	defaultRoute(app);
+	userRoute(app);
+	sessionRoute(app);
+	userInfoRoute(app);
+	accountRoute(app);
+	positionsRoute(app);
+	activitiesRoute(app);
+	searchRoute(app);
+	//other routes..
+	followRoute(app);
 };

--- a/src/routes/v1/user.route.ts
+++ b/src/routes/v1/user.route.ts
@@ -8,12 +8,18 @@ const userRoute = (app: Express) => {
 
 	// All paths have the prefix /api/v1/account/
 
-	router.post("/", validateResource(createUserSchema),(req, res) => {
+	router.post("/", validateResource(createUserSchema), (req, res) => {
 		userController.createUser(req, res);
 	});
 
 	router.get("/:email", async (req: Request, res: Response, next) => {
 		if (req.params.email && req.params.email.includes("@")) {
+			res.send(await userController.getUser(req.params));
+		} else next();
+	});
+
+	router.get("/:username", async (req: Request, res: Response, next) => {
+		if (req.params.username && req.params.username.length < 24) {
 			res.send(await userController.getUser(req.params));
 		} else next();
 	});

--- a/src/routes/v1/userInfo.route.ts
+++ b/src/routes/v1/userInfo.route.ts
@@ -5,18 +5,21 @@ const userInfoRoute = (app: Express) => {
 	const userInfoController = new UserInfoController();
 	const router = express.Router();
 
-
-    router.get("/:userId", async (req: Request, res: Response) => {
-		userInfoController.getUserInfo(req,res);
+	router.get("/", (req, res) => {
+		userInfoController.getUserInfos(req, res);
 	});
 
-	router.patch("/:userId" ,(req, res) => {
+	router.get("/:userId", async (req: Request, res: Response) => {
+		userInfoController.getUserInfo(req, res);
+	});
+
+	router.patch("/:userId", (req, res) => {
 		userInfoController.updateUserInfo(req, res);
 	});
 
 	router.patch("/alpaca/:userId", (req, res) => {
-		userInfoController.updateAlpacaToken(req,res);
-	})
+		userInfoController.updateAlpacaToken(req, res);
+	});
 
 	app.use("/api/v1/userInfo/", router);
 };

--- a/src/tests/7_Follow.test.ts
+++ b/src/tests/7_Follow.test.ts
@@ -141,7 +141,7 @@ describe("Follow service can", () => {
 				mockedUser.mockedInfo.userId.toJSON()
 			);
 			expect(unfollowRes.success).to.be.true;
-			expect(unfollowRes.data).to.be.greaterThan(0); // number of relationship deleted
+			expect(unfollowRes.data.numbDeleted).to.be.greaterThan(0); // number of relationship deleted
 
 			// double check
 			const isFollowed = await followService.verifyRelFollows(


### PR DESCRIPTION
Closes TS-317.

1. Added API for: follow, unfollow, get followers and followings for an account.
2. Edited some comments in method returns
3. Minor debug in test and `unfollow(..)`
4. API documentation is available at: https://documenter.getpostman.com/view/10545271/UVe9QU3y 

Note: For testing on Postman, you will need to first Login, then copy the `accessToken` to `Authentication` field -> Choose `Bearer-token` and paste the token there. 

![image](https://user-images.githubusercontent.com/60043570/151325776-aa9f4551-b3f9-47c9-b9bc-5d40df7ceac6.png)

