### PR TITLE
[TS-404] differentiate username and email key errors

### DIFF
--- a/src/db/service/user.service.ts
+++ b/src/db/service/user.service.ts
@@ -84,9 +84,13 @@ export default class UserService {
 				omit(user.toJSON(), "password")
 			);
 		} catch (error: any) {
-			if (error.message.includes("key error")) {
+			if (error.message.includes("username")) {
+				return messages.internalError("Username already exists");
+			} 
+			else if(error.message.includes("email")) {
 				return messages.internalError("Email already exists");
-			} else {
+			}
+			else {
 				return messages.internalError(error.message);
 			}
 		}


### PR DESCRIPTION
Small PR to differentiate username and email key errors. 
Username is now an index in the database 
![image](https://user-images.githubusercontent.com/30036024/153349229-dff2327b-f4bd-4c62-aa0e-79e3d64635e6.png)
