### PR TITLE
[TS-485] Follow request handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import express, { Express } from 'express'
+import express, { Express, NextFunction, Request, Response } from 'express'
 import helmet from 'helmet'
 import dotenv from 'dotenv'
 import cors from 'cors'
@@ -8,6 +8,7 @@ import deserializeUser from './middleware/deserializeUser'
 import neo4j from './db/neo4j/Neo4jInstance'
 import swaggerUI from 'swagger-ui-express'
 import YAML from 'yamljs'
+import { CustomError } from './utils/ErrorSchema/ErrorSchema'
 dotenv.config()
 
 const PORT = process.env.PORT || 5000
@@ -29,6 +30,15 @@ app.use(deserializeUser)
 
 // loading routes
 require('./routes/v1')(app)
+
+// default handler
+app.use((err: CustomError, req: Request, res: Response, next:NextFunction) => {
+	console.log('********************** ERROR ***************')
+	console.log(`Internal_Log >> ${err.message}`)
+	console.log('At: ' + new Date())
+	res.status(err?.status || 500)
+	res.send(err.message)
+})
 
 const server = app.listen(PORT, async () => {
 	await mongoInstance.connect()

--- a/src/middleware/requireUser.ts
+++ b/src/middleware/requireUser.ts
@@ -1,9 +1,10 @@
 import { NextFunction, Request, Response } from 'express'
+import { UnauthorizedError } from '../utils/ErrorSchema/ErrorSchema'
 
 const requireUser = (req: Request, res: Response, next: NextFunction) => {
 	const user = res.locals.user
 	if (!user) {
-		return res.sendStatus(403)
+		return next(new UnauthorizedError())
 	}
 	return next()
 }

--- a/src/modules/follows/FollowQueries.ts
+++ b/src/modules/follows/FollowQueries.ts
@@ -1,11 +1,11 @@
 export const followQueries = {
-        CREATE_RELATIONSHIP: `
+	CREATE_RELATIONSHIP: `
                 MERGE (src: User{userId: $src})
                 MERGE (target: User{userId: $target})
                 MERGE p=(src)-[r:Follows{isPending: $isPending}]->(target)
                 return count(p) as numOfPath, ID(r) as relId
         `,
-        GET_RELATIONSHION_BETWEEN_USERS: `
+	GET_RELATIONSHION_BETWEEN_USERS: `
                 MATCH p=(src: User{userId: $src})-[r:Follows]->(target: User{userId: $target})
                 WITH p
                 RETURN 
@@ -14,22 +14,38 @@ export const followQueries = {
                 ELSE false
                 END AS relExists
         `,
-        GET_FOLLOWS_FOR_USER: `
+	GET_FOLLOWS_FOR_USER: `
                 MATCH (n:User{userId: $userId})-[r:Follows{isPending: false}]->(m:User)
                 RETURN m.userId as followId
         `,
-        GET_FOLLOWERS_FOR_USER: `
+	GET_FOLLOWERS_FOR_USER: `
                 MATCH (n:User)-[r:Follows{isPending: false}]->(m:User{userId: $userId})
                 RETURN n.userId as followerId
         `,
-        DELETE_RELATIONSHIP_BY_USER_ID: `
+	DELETE_RELATIONSHIP_BY_USER_ID: `
                 MATCH (src: User{userId: $src})-[r:Follows{isPending:$isPending}]->(target: User{userId: $target})
                 DELETE r
                 RETURN COUNT(*) as numbDeleted
         `,
-        DELETE_USER_NODE_BY_ID: `
+	DELETE_USER_NODE_BY_ID: `
                 MATCH (n:User{userId: $userId})
                 DETACH DELETE n
                 RETURN COUNT(*) as numbDeleted                 
+        `,
+	SET_PENDING_REQUEST: `
+                MATCH (src:User)-[r:Follows]->(target: User)
+                WHERE ID(r) = $relId
+                SET r.isPending = $isPending
+                RETURN COUNT(*) as numbModified 
+        `,
+	GET_PENDING_REQUESTS_FOR_USER: `
+                MATCH (n:User)-[r:Follows{isPending: true}]->(m:User{userId: $userId})
+                RETURN n.userId as senderId, ID(r) as relId
+        `,
+	DELELTE_REQUEST_BY_ID: `
+                MATCH (src:User)-[r:Follows]->(target: User)
+                WHERE ID(r) = $relId
+                DELETE r
+                RETURN COUNT(*) as numbDeleted 
         `
 }

--- a/src/modules/follows/FollowRequestController.ts
+++ b/src/modules/follows/FollowRequestController.ts
@@ -1,0 +1,42 @@
+import { NextFunction, Request, Response } from 'express'
+import { isUndefined } from 'lodash'
+import { BadInputError, InternalError } from '../../utils/ErrorSchema/ErrorSchema'
+import FollowRequestService from './FollowRequestService'
+
+class FollowRequestController {
+	static verifyRelId (req: Request, res: Response, next: NextFunction) {
+		const relId = !isUndefined(req?.params?.relId) || !isUndefined(req?.body?.relId)
+			? (req.params.relId || req.body.relId)
+			: undefined
+
+		if (isUndefined(relId)) return next(new BadInputError('relationship id is not passed'))
+		else if (isNaN(relId)) return next(new BadInputError('relationship id contains only number'))
+		else next()
+	}
+
+	static verifyUserId (req: Request, res: Response, next: NextFunction) {
+		const userId = req?.params?.userId !== undefined || req?.body?.userId !== undefined
+			? req.params.userId || req.body.userId
+			: undefined
+
+		if (!userId) return next(new BadInputError('user id is undefined'))
+		else next()
+	}
+
+	static async declinePendingRequest (req: Request, res: Response, next: NextFunction) {
+		const response = await FollowRequestService.declinePendingRequest(Number.parseInt(req.params.relId || req.body.relId))
+		return response.success ? res.send(response.data) : next(new InternalError(response.message))
+	}
+
+	static async acceptPendingRequest (req: Request, res: Response, next: NextFunction) {
+		const response = await FollowRequestService.acceptPendingRequest(Number.parseInt(req.params.relId || req.body.relId))
+		return response.success ? res.send(response.data) : next(new InternalError(response.message))
+	}
+
+	static async getPendingRequests (req: Request, res: Response, next: NextFunction) {
+		const response = await FollowRequestService.getPendingRequests(req.params.userId || req.body.userId)
+		return response.success ? res.send(response.data) : next(new InternalError(response.message))
+	}
+}
+
+export default FollowRequestController

--- a/src/modules/follows/FollowRequestService.ts
+++ b/src/modules/follows/FollowRequestService.ts
@@ -1,0 +1,98 @@
+import { UserInfo } from '../../db/models/userInfo.model'
+import neo4jInstance, { QueryMode } from '../../db/neo4j/Neo4jInstance'
+import { followQueries } from './FollowQueries'
+import neo4j, { Record } from 'neo4j-driver'
+
+class FollowRequestService {
+	/**
+	 * Decline a request
+	 * @param relId ID of the request
+	 * @returns \{success, message, data: numbDeleted}
+	 */
+	static async declinePendingRequest (relId: number) {
+		const query = followQueries.DELELTE_REQUEST_BY_ID
+		const params = { relId }
+
+		const queryResponse = await neo4jInstance.runQueryInTransaction(query, params, QueryMode.write)
+		if (queryResponse.success && queryResponse.data[0]) {
+			// field_name based on the RETURN in the query
+			const numbDeleted = neo4j.integer.toNumber(queryResponse.data[0].get('numbDeleted'))
+			return {
+				success: true,
+				message: queryResponse.message,
+				data: { numbDeleted: numbDeleted }
+			}
+		} else {
+			return queryResponse
+		}
+	}
+
+	/**
+	 * Accepting a request
+	 * @param relId relationship ID / Request ID
+	 * @returns
+	 */
+	static acceptPendingRequest (relId: number) {
+		return FollowRequestService.setPendingRequest(relId, false)
+	}
+
+	/**
+	 * Return the requests of the a user
+	 * @param userId the user id
+	 * @returns list of request
+	 */
+	static async getPendingRequests (userId: UserInfo['userId']) {
+		const query = followQueries.GET_PENDING_REQUESTS_FOR_USER
+		const params = {
+			userId: userId
+		}
+
+		const queryResponse = await neo4jInstance.runQueryInTransaction(query, params, QueryMode.read)
+		if (queryResponse.success && queryResponse.data[0]) {
+			// field_name based on the RETURN in the query
+			return {
+				success: true,
+				message: queryResponse.message,
+				data: this.parseRequestFromNeo4j(queryResponse.data)
+			}
+		} else {
+			return queryResponse
+		}
+	}
+
+	/**
+	 * Set a request to pending. This function is used in test to avoid creating unnecessary new request
+	 * @param relId
+	 * @returns
+	 */
+	static async setPendingRequest (relId: number, isPending: boolean) {
+		const query = followQueries.SET_PENDING_REQUEST
+		const params = { relId, isPending }
+
+		const queryResponse = await neo4jInstance.runQueryInTransaction(query, params, QueryMode.write)
+		if (queryResponse.success && queryResponse.data[0]) {
+			// field_name based on the RETURN in the query
+			const numbModified = neo4j.integer.toNumber(queryResponse.data[0].get('numbModified'))
+			return {
+				success: true,
+				message: queryResponse.message,
+				data: { numbModified }
+			}
+		} else {
+			return queryResponse
+		}
+	}
+
+	static parseRequestFromNeo4j (rows: Record[]) {
+		const requestArr = []
+		for (const row of rows) {
+			requestArr.push({
+				senderId: neo4j.integer.toNumber(row.get('senderId')),
+				requestId: neo4j.integer.toNumber(row.get('relId'))
+			})
+		}
+		return requestArr
+	}
+}
+
+export default FollowRequestService

--- a/src/modules/follows/FollowRequestService.ts
+++ b/src/modules/follows/FollowRequestService.ts
@@ -87,8 +87,8 @@ class FollowRequestService {
 		const requestArr = []
 		for (const row of rows) {
 			requestArr.push({
-				senderId: neo4j.integer.toNumber(row.get('senderId')),
-				requestId: neo4j.integer.toNumber(row.get('relId'))
+				senderId: row.get('senderId'),
+				relId: neo4j.integer.toNumber(row.get('relId'))
 			})
 		}
 		return requestArr

--- a/src/modules/follows/FollowRoute.ts
+++ b/src/modules/follows/FollowRoute.ts
@@ -1,6 +1,7 @@
 import { Express, Router } from 'express'
 import requireUser from '../../middleware/requireUser'
 import FollowController from './FollowController'
+import FollowRequestController from './FollowRequestController'
 
 const followRoute = (app: Express) => {
 	const controller = new FollowController()
@@ -16,6 +17,9 @@ const followRoute = (app: Express) => {
 		controller.getFollowers(req, res)
 	})
 
+	// get request
+	router.get('/requests/:userId', requireUser, FollowRequestController.verifyUserId, FollowRequestController.getPendingRequests)
+
 	// follow another
 	router.post('/follow', requireUser, (req, res) => {
 		controller.follows(req, res)
@@ -25,6 +29,12 @@ const followRoute = (app: Express) => {
 	router.post('/unfollow', requireUser, (req, res) => {
 		controller.unfollows(req, res)
 	})
+
+	// accept request
+	router.post('/requests/accept/:relId', requireUser, FollowRequestController.verifyRelId, FollowRequestController.acceptPendingRequest)
+
+	// decline request
+	router.post('/requests/decline/:relId', requireUser, FollowRequestController.verifyRelId, FollowRequestController.declinePendingRequest)
 
 	app.use('/api/v1/following/', router)
 }

--- a/src/modules/follows/FollowService.ts
+++ b/src/modules/follows/FollowService.ts
@@ -48,7 +48,7 @@ class FollowService extends Neo4JHelper {
 
 			// Notify target user if it is a private account
 			if (targerUserInfo?.isPrivate && !bypassPrivate && res.success) {
-				const notiMessage = `${srcUserId?.firstname} ${srcUserId?.lastname} has requested to follow you`
+				const notiMessage = `${targerUserInfo.firstname} ${targerUserInfo.lastname} has requested to follow you`
 				await this.notificationsService.notify(targetUserId, notiMessage, 'followRequest')
 			}
 

--- a/src/modules/follows/FollowService.ts
+++ b/src/modules/follows/FollowService.ts
@@ -3,7 +3,7 @@ import neo4jInstance, { QueryMode } from '../../db/neo4j/Neo4jInstance'
 import UserInfoService from '../../db/service/UserInfoService'
 import { followQueries } from './FollowQueries'
 import mongoose from 'mongoose'
-import neo4j from 'neo4j-driver'
+import neo4j, { Record } from 'neo4j-driver'
 import NotificationsService from '../notifications/NotificationsService'
 import Neo4JHelper from '../utils/Neo4JHelper'
 
@@ -42,19 +42,17 @@ class FollowService extends Neo4JHelper {
 				userId: targetUserMongoId
 			})
 
-			if (targerUserInfo?.isPrivate && !bypassPrivate) {
-				const res = { success: false, message: 'This function is not ready, work is in progress', data: { relId: -1 } }
-				if (res.success) {
-					this.notificationsService.notify(targerUserInfo?.firstname + ' ' + targerUserInfo?.lastname, '[User]' + ' has requested to follow you', 'followRequest')
-				}
-				return res
-			} else {
-				const res = await this.createRelFollows(srcUserId, targetUserId)
-				if (res.success) {
-					this.notificationsService.notify(targetUserId, targerUserInfo?.firstname + ' ' + targerUserInfo?.lastname + ' has requested to follow you', 'followRequest')
-				}
-				return res
+			const res = targerUserInfo?.isPrivate && !bypassPrivate
+				? await this.createRelFollows(srcUserId, targetUserId, true)
+				: await this.createRelFollows(srcUserId, targetUserId)
+
+			// Notify target user if it is a private account
+			if (targerUserInfo?.isPrivate && !bypassPrivate && res.success) {
+				const notiMessage = `${srcUserId?.firstname} ${srcUserId?.lastname} has requested to follow you`
+				await this.notificationsService.notify(targetUserId, notiMessage, 'followRequest')
 			}
+
+			return res
 		} catch (error: any) {
 			console.log(error.message)
 			return { success: false, message: 'Invalid target userID', data: { relId: -1 } }
@@ -170,6 +168,97 @@ class FollowService extends Neo4JHelper {
 	 */
 	unFollow (srcUserId: UserInfo['userId'], targetUserId: UserInfo['userId']) {
 		return this.deleteRelFollows(srcUserId, targetUserId)
+	}
+
+	/**
+	 * Decline a request
+	 * @param srcUserId ID of the actor
+	 * @param targetUserId ID of the target
+	 * @returns \{success, message, data: numbDeleted}
+	 */
+	async declinePendingRequest (relId: number) {
+		const query = followQueries.DELELTE_REQUEST_BY_ID
+		const params = { relId }
+
+		const queryResponse = await neo4jInstance.runQueryInTransaction(query, params, QueryMode.write)
+		if (queryResponse.success && queryResponse.data[0]) {
+			// field_name based on the RETURN in the query
+			const numbDeleted = neo4j.integer.toNumber(queryResponse.data[0].get('numbDeleted'))
+			return {
+				success: true,
+				message: queryResponse.message,
+				data: { numbDeleted: numbDeleted }
+			}
+		} else {
+			return queryResponse
+		}
+	}
+
+	/**
+	 * Accepting a request
+	 * @param relId relationship ID / Request ID
+	 * @returns
+	 */
+	acceptPendingRequest (relId: number) {
+		return this.setPendingRequest(relId, false)
+	}
+
+	/**
+	 * Return the status of the relationship
+	 * @param relId
+	 * @returns
+	 */
+	async getPendingRequests (userId: UserInfo['userId']) {
+		const query = followQueries.GET_PENDING_REQUESTS_FOR_USER
+		const params = {
+			userId: userId
+		}
+
+		const queryResponse = await neo4jInstance.runQueryInTransaction(query, params, QueryMode.read)
+		if (queryResponse.success && queryResponse.data[0]) {
+			// field_name based on the RETURN in the query
+			return {
+				success: true,
+				message: queryResponse.message,
+				data: this.parseRequestFromNeo4j(queryResponse.data)
+			}
+		} else {
+			return queryResponse
+		}
+	}
+
+	/**
+	 * Set a request to pending. This function is used in test to avoid creating unnecessary new request
+	 * @param relId
+	 * @returns
+	 */
+	async setPendingRequest (relId: number, isPending: boolean) {
+		const query = followQueries.SET_PENDING_REQUEST
+		const params = { relId, isPending }
+
+		const queryResponse = await neo4jInstance.runQueryInTransaction(query, params, QueryMode.write)
+		if (queryResponse.success && queryResponse.data[0]) {
+			// field_name based on the RETURN in the query
+			const numbModified = neo4j.integer.toNumber(queryResponse.data[0].get('numbModified'))
+			return {
+				success: true,
+				message: queryResponse.message,
+				data: { numbModified }
+			}
+		} else {
+			return queryResponse
+		}
+	}
+
+	parseRequestFromNeo4j (rows: Record[]) {
+		const requestArr = []
+		for (const row of rows) {
+			requestArr.push({
+				senderId: neo4j.integer.toNumber(row.get('senderId')),
+				requestId: neo4j.integer.toNumber(row.get('relId'))
+			})
+		}
+		return requestArr
 	}
 
 	/**

--- a/src/modules/notifications/NotificationsController.ts
+++ b/src/modules/notifications/NotificationsController.ts
@@ -3,28 +3,28 @@ import NotificationsService from './NotificationsService'
 
 class NotificationsController {
     private notificationsService: NotificationsService;
-    constructor() {
-        this.notificationsService = new NotificationsService()
+    constructor () {
+    	this.notificationsService = new NotificationsService()
     }
 
-    async getNotifications(req: Request, res: Response) {
-        const userId = req.params.userId || '-1'
-        const response = await this.notificationsService.getNotifications(userId)
-        return response.success ? res.send(response.data) : res.status(400).send(response)
+    async getNotifications (req: Request, res: Response) {
+    	const userId = req.params.userId || '-1'
+    	const response = await this.notificationsService.getNotifications(userId)
+    	return response.success ? res.send(response.data) : res.status(400).send(response)
     }
 
-    async readNotification(req: Request, res: Response) {
-        const userId = req.params.userId || '-1'
-        const notificationId = req.params.notificationId || '-1'
-        const response = await this.notificationsService.markNotificationRead(userId, notificationId)
-        return response.success ? res.send(response.data) : res.status(400).send(response)
+    async readNotification (req: Request, res: Response) {
+    	const userId = req.params.userId || '-1'
+    	const notificationId = req.params.notificationId || '-1'
+    	const response = await this.notificationsService.markNotificationRead(userId, notificationId)
+    	return response.success ? res.send(response.data) : res.status(400).send(response)
     }
 
-    async manageNotifications(req: Request, res: Response) {
-        const userId = req.body.userId || '-1'
-        const notifications = req.body.notifications
-        const response = this.notificationsService.manageNotifications(userId, notifications)
-        return response.success ? res.send(response.data) : res.status(400).send(response)
+    async manageNotifications (req: Request, res: Response) {
+    	const userId = req.body.userId || '-1'
+    	const notifications = req.body.notifications
+    	const response = this.notificationsService.manageNotifications(userId, notifications)
+    	return response.success ? res.send(response.data) : res.status(400).send(response)
     }
 }
 

--- a/src/modules/notifications/NotificationsService.ts
+++ b/src/modules/notifications/NotificationsService.ts
@@ -89,8 +89,13 @@ class NotificationsService {
 		const queryResponse = await neo4jInstance.runQueryInTransaction(query, params, QueryMode.write)
 		if (queryResponse.success && queryResponse.data[0]) {
 			// field_name based on the RETURN in the query
-			const notifs = queryResponse.data[0].get('userNotifications')
-			const ids = queryResponse.data[0].get('notifId')
+			const notifs = []
+			const ids = []
+			for (const row of queryResponse.data) {
+				notifs.push(row.get('userNotifications')[0])
+				ids.push(neo4j.integer.toNumber(row.get('notifId')))
+			}
+
 			return {
 				success: true,
 				message: queryResponse.message,

--- a/src/tests/7_Follow.test.ts
+++ b/src/tests/7_Follow.test.ts
@@ -7,6 +7,7 @@ import UserInfoCollection, { UserInfo } from '../db/models/userInfo.model'
 import NotificationsService from '../modules/notifications/NotificationsService'
 
 import { cleanupMockedUserInfo, createAndTestUserInfo, mockedActorUserInput, mockedTargetUserInput } from './2_UserInfo.test'
+import FollowRequestService from '../modules/follows/FollowRequestService'
 
 export interface MockedUser {
 	mockedUser: UserDocument;
@@ -107,28 +108,28 @@ describe('Follow service can', () => {
 		})
 
 		it('private target user receives request', async () => {
-			const result = await followService.getPendingRequests(mockedFollower.mockedInfo.userId.toJSON())
+			const result = await FollowRequestService.getPendingRequests(mockedFollower.mockedInfo.userId.toJSON())
 			expect(result.success).to.be.true
 			expect(result.data.length).to.greaterThanOrEqual(1)
 		})
 
 		it('private target user accepts request', async () => {
 			expect(relId).to.be.a('number')
-			const result = await followService.acceptPendingRequest(relId)
+			const result = await FollowRequestService.acceptPendingRequest(relId)
 			expect(result.success).to.be.true
 			expect(result.data.numbModified).to.equal(1)
 		})
 
 		it('set request to pending for test purpose', async () => {
 			expect(relId).to.be.a('number')
-			const result = await followService.setPendingRequest(relId, false)
+			const result = await FollowRequestService.setPendingRequest(relId, false)
 			expect(result.success).to.be.true
 			expect(result.data.numbModified).to.equal(1)
 		})
 
 		it('private target user declines request', async () => {
 			expect(relId).to.be.a('number')
-			const result = await followService.declinePendingRequest(relId)
+			const result = await FollowRequestService.declinePendingRequest(relId)
 			expect(result.success).to.be.true
 			expect(result.data.numbDeleted).to.equal(1)
 		})

--- a/src/tests/7_Follow.test.ts
+++ b/src/tests/7_Follow.test.ts
@@ -53,10 +53,14 @@ describe('Follow service can', () => {
 				userInfoService: userInfoService,
 				userService: userService
 			})
+
+			// set mockedFollower to be private account
+			const updateMockedFollower = await userInfoService.updateUserInfo({ userId: mockedFollower.mockedInfo.userId.toJSON() }, { isPrivate: true }, { new: true })
+			expect(updateMockedFollower).not.equal(undefined)
 		})
 	})
 
-	describe('follow users', () => {
+	describe('follow public users', () => {
 		it('follow another user', async () => {
 			// mockedFollower sends request to mockedUser
 			const result = await followService.follow(
@@ -80,23 +84,53 @@ describe('Follow service can', () => {
 			const result = await followService.follow(123, { id: 'object type id' })
 			expect(result.success).to.be.false
 		})
+	})
 
-		it('target user receives notification', async () => {
+	describe('follow private users', () => {
+		let relId:number
+		it('follow a private user', async () => {
+			// mockedFollower sends request to mockedUser
+			const result = await followService.follow(
+				mockedUser.mockedInfo.userId.toJSON(),
+				mockedFollower.mockedInfo.userId.toJSON()
+			)
+			expect(result.success).to.be.true
+			expect(result.data.relId).not.equal(undefined)
+			relId = result.data.relId
+		})
+
+		it('private target user receives notification', async () => {
 			const result = await notificationsService.getNotifications(
-				mockedUser.mockedInfo.userId.toJSON()
+				mockedFollower.mockedInfo.userId.toJSON()
 			)
 			expect(result.data.notifications.length).equal(1)
 		})
 
-		it.skip('recevie notification if the profile is private', () => {
-			// mockedUser gets notification if profile is private; public by default
-			// only do public requests for now
+		it('private target user receives request', async () => {
+			const result = await followService.getPendingRequests(mockedFollower.mockedInfo.userId.toJSON())
+			expect(result.success).to.be.true
+			expect(result.data.length).to.greaterThanOrEqual(1)
 		})
 
-		it.skip('follow request is pending if the profile is private', () => {
-			// the service searches for the relationship, the relationship should have status as "pending"
-			// look for status as 1 direction
-			// only do public requests for now
+		it('private target user accepts request', async () => {
+			expect(relId).to.be.a('number')
+			const result = await followService.acceptPendingRequest(relId)
+			expect(result.success).to.be.true
+			expect(result.data.numbModified).to.equal(1)
+		})
+
+		it('set request to pending for test purpose', async () => {
+			expect(relId).to.be.a('number')
+			const result = await followService.setPendingRequest(relId, false)
+			expect(result.success).to.be.true
+			expect(result.data.numbModified).to.equal(1)
+		})
+
+		it('private target user declines request', async () => {
+			expect(relId).to.be.a('number')
+			const result = await followService.declinePendingRequest(relId)
+			expect(result.success).to.be.true
+			expect(result.data.numbDeleted).to.equal(1)
 		})
 	})
 

--- a/src/utils/ErrorSchema/ErrorSchema.ts
+++ b/src/utils/ErrorSchema/ErrorSchema.ts
@@ -18,3 +18,11 @@ export class BadInputError extends Error implements CustomError {
     	this.status = 400
     }
 }
+
+export class InternalError extends Error implements CustomError {
+    status: number
+    constructor (msg = 'Unexpected error') {
+    	super(msg)
+    	this.status = 500
+    }
+}

--- a/src/utils/ErrorSchema/ErrorSchema.ts
+++ b/src/utils/ErrorSchema/ErrorSchema.ts
@@ -1,0 +1,20 @@
+/* eslint-disable no-mixed-spaces-and-tabs */
+export interface CustomError extends Error{
+    status: number
+}
+
+export class UnauthorizedError extends Error implements CustomError {
+    status: number
+    constructor () {
+    	super('Your request is unauthorized. Please login or contact admin')
+    	this.status = 403
+    }
+}
+
+export class BadInputError extends Error implements CustomError {
+    status: number
+    constructor (msg = 'Unexpected error') {
+    	super(msg)
+    	this.status = 400
+    }
+}


### PR DESCRIPTION
### List of new API endpoints

1. Get requests: GET `api/v1/following/requests/:userId`
2. Accept a request: POST `api/v1/following/requests/accept/:relId`
3. Decline a request: POST `api/v1/following/requests/decline/:relId`

### Make a request to follow a private account

![Screenshot from 2022-03-29 15-50-15](https://user-images.githubusercontent.com/60043570/160705989-78d9274f-8972-4aad-91f9-1479094e3da1.png)

### Target will receive notification

![Screenshot from 2022-03-29 16-21-53](https://user-images.githubusercontent.com/60043570/160706025-1f8e71d2-983d-4b61-abe2-cdd0b2e0d36b.png)

### Target will receive a list of requests

![Screenshot from 2022-03-29 16-26-35](https://user-images.githubusercontent.com/60043570/160706081-9720ef58-7e12-47f0-b7aa-956dfda429db.png)

### We can either accept or decline a request 
![Screenshot from 2022-03-29 16-42-36](https://user-images.githubusercontent.com/60043570/160706101-8cd5f635-cef6-4720-8b45-229b0c908b9c.png)

### One we accept or decline, the number of pendingRequest is also updated
![Screenshot from 2022-03-29 16-42-57](https://user-images.githubusercontent.com/60043570/160706118-3c759ec9-7a4d-44de-9144-71c36e574bfa.png)

